### PR TITLE
:pencil: add ScheduleAddEvents support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Ragoon is simple Garoon 3 API Client.
 
 ```
 service = Ragoon::Services::Schedule.new
-events = service.schedule_get_event
+events = service.schedule_get_events
 
 => [
 {:id=>"1334236", :url=>"https://example.co.jp/cgi-bin/cbgrn/grn.cgi/schedule/view?event=1334236", :title=>"ログ収集システムについて", :start_at=>"2016-01-15 13:30:00 +0900", :end_at=>"2016-01-15 14:00
@@ -20,6 +20,19 @@ events = service.schedule_get_event
 {:id=>"1336040", :url=>"https://example.co.jp/cgi-bin/cbgrn/grn.cgi/schedule/view?event=1336040", :title=>"スプリントMTG", :start_at=>"2016-01-15 14:00:00 +0900", :end_at=>"2016-01-15 15:00:00
 +0900", :plan=>"社内MTG", :facilities=>["会議室 13-e","会議室 13-f"], :private=>false, :allday=>false},
 ]
+
+service.schedule_add_event(
+  title: 'プロジェクトキックオフ',
+  description: '新規プロジェクト概要説明',
+  start_at: Time.new(2016, 1, 15, 13, 0),
+  end_at: Time.new(2016, 1, 15, 13, 30),
+  plan: '社内MTG',
+  users: [1],
+  private: false,
+  allday: false
+)
+
+=> {:id=>"1338211", :url=>"https://example.co.jp/cgi-bin/cbgrn/grn.cgi/schedule/view?event=1338211", :title=>"プロジェクトキックオフ", :start_at=>"2016-01-15 13:00:00 +0900", :end_at=>"2016-01-15 13:30:00+0900", :plan=>"社内MTG", :facilities=>[], :users=>[{:id => 1, :name => "田中　太郎"}], :private=>false, :allday=>false}
 ```
 
 ### Notification

--- a/lib/ragoon/services/schedule.rb
+++ b/lib/ragoon/services/schedule.rb
@@ -18,19 +18,83 @@ class Ragoon::Services::Schedule < Ragoon::Services
 
     events = client.result_set.xpath('//schedule_event').
              find_all { |ev| ev[:event_type] != 'banner' }.map do |event|
-      period = start_and_end(event)
-      {
-        id:         event[:id],
-        url:        event_url(event[:id]),
-        title:      event[:detail],
-        start_at:   period[:start_at],
-        end_at:     period[:end_at],
-        plan:       event[:plan],
-        facilities: facility_names(event),
-        private:    !(event[:public_type] == 'public'),
-        allday:     event[:allday] == 'true',
-      }
+      parse_event(event)
     end
+  end
+
+  def schedule_add_event(options = {})
+    action_name = 'ScheduleAddEvents'
+
+    options = default_options(action_name).merge(options)
+
+    body_node = Ragoon::XML.create_node(action_name)
+    parameter_node = Ragoon::XML.create_node('parameters')
+    body_node.add_child(parameter_node)
+
+    schedule_event_node = Ragoon::XML.create_node(
+      'schedule_event',
+      {
+        xmlns:       '',
+        id:          'dummy',
+        version:     'dummy',
+        event_type:  'normal',
+        plan:        options[:plan],
+        detail:      options[:title],
+        description: options[:description],
+        allday:      options[:allday],
+        public_type: (options[:private] ? 'private' : 'public')
+      }
+    )
+    parameter_node.add_child(schedule_event_node)
+
+    members_node = Ragoon::XML.create_node(
+      'members',
+      xmlns: 'http://schemas.cybozu.co.jp/schedule/2008'
+    )
+    schedule_event_node.add_child(members_node)
+    if options[:users]
+      options[:users].each do |user|
+        member_node = Ragoon::XML.create_node('member')
+        user_node = Ragoon::XML.create_node('user', id: user.to_i)
+        member_node.add_child(user_node)
+        members_node.add_child(member_node)
+      end
+    end
+
+    when_node = Ragoon::XML.create_node(
+      'when',
+      xmlns: 'http://schemas.cybozu.co.jp/schedule/2008'
+    )
+    date_node = Ragoon::XML.create_node(
+      'datetime',
+      start: options[:start_at].utc.strftime('%FT%T'),
+      end:   options[:end_at].utc.strftime('%FT%T')
+    )
+    when_node.add_child(date_node)
+    schedule_event_node.add_child(when_node)
+
+    client.request(action_name, body_node)
+
+    events = client.result_set.xpath('//schedule_event').
+             find_all { |ev| ev[:event_type] != 'banner' }.map { |event|
+      parse_event(event)
+    }.first
+  end
+
+  def parse_event(event)
+    period = start_and_end(event)
+    {
+      id:         event[:id],
+      url:        event_url(event[:id]),
+      title:      event[:detail],
+      start_at:   period[:start_at],
+      end_at:     period[:end_at],
+      plan:       event[:plan],
+      facilities: facility_names(event),
+      users:      users_info(event),
+      private:    !(event[:public_type] == 'public'),
+      allday:     event[:allday] == 'true',
+    }
   end
 
   def event_url(id)
@@ -41,6 +105,17 @@ class Ragoon::Services::Schedule < Ragoon::Services
     event.xpath('ev:members', ev: "http://schemas.cybozu.co.jp/schedule/2008").
       children.map { |c| c.xpath('ev:facility', ev: "http://schemas.cybozu.co.jp/schedule/2008").first }.
       compact.map { |n| n[:name] }
+  end
+
+  def users_info(event)
+    event.xpath('ev:members', ev: "http://schemas.cybozu.co.jp/schedule/2008").
+      children.map { |c| c.xpath('ev:user', ev: "http://schemas.cybozu.co.jp/schedule/2008").first }.
+      compact.map do |n|
+        {
+          id: n[:id].to_i,
+          name: n[:name].to_s,
+        }
+      end
   end
 
   def start_and_end(event)

--- a/lib/ragoon/services/schedule.rb
+++ b/lib/ragoon/services/schedule.rb
@@ -41,7 +41,6 @@ class Ragoon::Services::Schedule < Ragoon::Services
         plan:        options[:plan],
         detail:      options[:title],
         description: options[:description],
-        allday:      options[:allday],
         public_type: (options[:private] ? 'private' : 'public')
       }
     )
@@ -65,11 +64,20 @@ class Ragoon::Services::Schedule < Ragoon::Services
       'when',
       xmlns: 'http://schemas.cybozu.co.jp/schedule/2008'
     )
-    date_node = Ragoon::XML.create_node(
-      'datetime',
-      start: options[:start_at].utc.strftime('%FT%T'),
-      end:   options[:end_at].utc.strftime('%FT%T')
-    )
+    date_node =
+      if options[:allday]
+        Ragoon::XML.create_node(
+          'date',
+          start: options[:start_at].strftime('%F'),
+          end:   options[:end_at].strftime('%F')
+        )
+      else
+        Ragoon::XML.create_node(
+          'datetime',
+          start: options[:start_at].utc.strftime('%FT%T'),
+          end:   options[:end_at].utc.strftime('%FT%T')
+        )
+      end
     when_node.add_child(date_node)
     schedule_event_node.add_child(when_node)
 


### PR DESCRIPTION
we can register a new schedule :smiley: 

``` ruby
service = Ragoon::Services::Schedule.new
service.schedule_add_event(
  title: '新規プロジェクトキックオフ',
  description: 'プロジェクト概要の共有など',
  start_at: Time.new(2016, 3, 14, 14, 0),
  end_at: Time.new(2016, 3, 14, 15, 0),
  plan: '社内MTG',
  users: [100, 148, 1024],
  private: false,
  allday: false
)
```
