### PR TITLE
Enable to initialize service with secret options

### DIFF
--- a/lib/ragoon.rb
+++ b/lib/ragoon.rb
@@ -11,16 +11,12 @@ require 'rest-client'
 module Ragoon
   @@secret_options = {}
 
-  def self.garoon_endpoint
-    ENV['GAROON_ENDPOINT'] || secret_options[:garoon_endpoint] || raise_option_error('endpoint')
-  end
-
-  def self.garoon_username
-    ENV['GAROON_USERNAME'] || secret_options[:garoon_username] || raise_option_error('username')
-  end
-
-  def self.garoon_password
-    ENV['GAROON_PASSWORD'] || secret_options[:garoon_password] || raise_option_error('password')
+  def self.default_options
+    {
+      endpoint: ENV['GAROON_ENDPOINT'] || secret_options[:garoon_endpoint] || raise_option_error('endpoint'),
+      username: ENV['GAROON_USERNAME'] || secret_options[:garoon_username] || raise_option_error('username'),
+      password: ENV['GAROON_PASSWORD'] || secret_options[:garoon_password] || raise_option_error('password')
+    }
   end
 
   def self.raise_option_error(type)

--- a/lib/ragoon/client.rb
+++ b/lib/ragoon/client.rb
@@ -1,14 +1,15 @@
 class Ragoon::Client
   attr_reader :endpoint, :response
 
-  def initialize(endpoint)
+  def initialize(endpoint, options)
     @endpoint = endpoint
+    @options = options
   end
 
   def request(action_name, body_node)
     @action_name = action_name
     @body_node = body_node
-    @response = RestClient.post(endpoint, Ragoon::XML.render(action_name, body_node))
+    @response = RestClient.post(endpoint, Ragoon::XML.render(action_name, body_node, @options))
   end
 
   def result_set

--- a/lib/ragoon/services.rb
+++ b/lib/ragoon/services.rb
@@ -6,14 +6,14 @@ class Ragoon::Services
 
   attr_reader :client, :action_type
 
-  def initialize
+  def initialize(options = Ragoon.default_options)
+    @options = options
     @action_type = self.class.name.split('::').pop.downcase.to_sym
-    @client = Ragoon::Client.new(self.endpoint)
+    @client = Ragoon::Client.new(self.endpoint, options)
   end
 
   def endpoint
-    endpoint = URI(Ragoon.garoon_endpoint)
-    "#{endpoint.scheme}://#{endpoint.host}#{endpoint.path}#{SERVICE_LOCATIONS[action_type]}"
+    "#{base_endpoint}#{SERVICE_LOCATIONS[action_type]}"
   end
 
   def self.start_and_end(date = Date.today)
@@ -22,4 +22,12 @@ class Ragoon::Services
       end:   ((date + 1).to_time - 1).utc,
     }
   end
+
+  private
+
+  def base_endpoint
+    endpoint = URI(@options[:endpoint])
+    "#{endpoint.scheme}://#{endpoint.host}#{endpoint.path}"
+  end
+
 end

--- a/lib/ragoon/services/schedule.rb
+++ b/lib/ragoon/services/schedule.rb
@@ -106,7 +106,7 @@ class Ragoon::Services::Schedule < Ragoon::Services
   end
 
   def event_url(id)
-    "#{Ragoon::garoon_endpoint.gsub(/\?.*\Z/, '')}/schedule/view?event=#{id}"
+    "#{base_endpoint}/schedule/view?event=#{id}"
   end
 
   def facility_names(event)

--- a/lib/ragoon/xml.rb
+++ b/lib/ragoon/xml.rb
@@ -2,8 +2,8 @@ module Ragoon::XML
   ACTION_PLACEHOLDER = '<!-- REQUEST_ACTION -->'.freeze
   BODY_PLACEHOLDER   = '<!-- REQUEST_BODY -->'.freeze
 
-  def self.render(action_name, body_node)
-    template.dup.
+  def self.render(action_name, body_node, options)
+    template(options).dup.
       gsub!(ACTION_PLACEHOLDER, action_name).
       gsub!(BODY_PLACEHOLDER,   body_node.to_xml)
   end
@@ -16,7 +16,7 @@ module Ragoon::XML
     node
   end
 
-  def self.template
+  def self.template(options)
     <<"XML"
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope"
@@ -33,8 +33,8 @@ module Ragoon::XML
               SOAP-ENV:mustUnderstand="1"
               xmlns="http://schemas.xmlsoap.org/ws/2002/12/secext">
       <UsernameToken wsu:Id="id">
-        <Username>#{Ragoon.garoon_username}</Username>
-        <Password>#{Ragoon.garoon_password}</Password>
+        <Username>#{options[:username]}</Username>
+        <Password>#{options[:password]}</Password>
       </UsernameToken>
     </Security>
     <Timestamp SOAP-ENV:mustUnderstand="1" Id="id"

--- a/test/test_ragoon_services.rb
+++ b/test/test_ragoon_services.rb
@@ -58,6 +58,16 @@ class TestRagoonServices < Test::Unit::TestCase
                    service.endpoint)
     end
 
+    test 'by argument' do
+      service = Ragoon::Services::Schedule.new(
+        endpoint: "http://example.com/by_arg",
+        username: "username",
+        password: "password"
+      )
+      assert_equal("http://example.com/by_arg/cbpapi/schedule/api?",
+                   service.endpoint)
+    end
+
     teardown do
       ENV.delete('GAROON_ENDPOINT')
       ENV.delete('GAROON_USERNAME')

--- a/test/test_ragoon_services.rb
+++ b/test/test_ragoon_services.rb
@@ -23,4 +23,47 @@ class TestRagoonServices < Test::Unit::TestCase
       assert_equal(result[:end], ((current_date + 1).to_time - 1).utc)
     end
   end
+
+  sub_test_case '.endpoint' do
+    test 'by ENV["garoon_endpoint"]' do
+      ENV['GAROON_ENDPOINT'] = "http://example.com/by_env"
+      ENV['GAROON_USERNAME'] = "username"
+      ENV['GAROON_PASSWORD'] = "password"
+      service = Ragoon::Services::Schedule.new
+      assert_equal("http://example.com/by_env/cbpapi/schedule/api?",
+                   service.endpoint)
+    end
+
+    test 'by secret_options' do
+      opts = {
+        garoon_endpoint: "http://example.com/by_secret",
+        garoon_username: "username",
+        garoon_password: "password"
+      }
+      Ragoon.class_variable_set :@@secret_options, opts
+      service = Ragoon::Services::Schedule.new
+      assert_equal("http://example.com/by_secret/cbpapi/schedule/api?",
+                   service.endpoint)
+    end
+
+    test 'with query' do
+      opts = {
+        garoon_endpoint: "http://example.com/cgi?p1=val&p2=val",
+        garoon_username: "username",
+        garoon_password: "password"
+      }
+      Ragoon.class_variable_set :@@secret_options, opts
+      service = Ragoon::Services::Schedule.new
+      assert_equal("http://example.com/cgi/cbpapi/schedule/api?",
+                   service.endpoint)
+    end
+
+    teardown do
+      ENV.delete('GAROON_ENDPOINT')
+      ENV.delete('GAROON_USERNAME')
+      ENV.delete('GAROON_PASSWORD')
+      Ragoon.class_variable_set :@@secret_options, {}
+    end
+  end
+
 end

--- a/test/test_ragoon_services_schedule.rb
+++ b/test/test_ragoon_services_schedule.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+class TestRagoonServicesSchedule < Test::Unit::TestCase
+
+  sub_test_case '.event_url(id)' do
+    test 'endpoint without query' do
+      opts = {
+        garoon_endpoint: "http://example.com/path/to",
+        garoon_username: "username",
+        garoon_password: "password"
+      }
+      Ragoon.class_variable_set :@@secret_options, opts
+      service = Ragoon::Services::Schedule.new
+      assert_equal("http://example.com/path/to/schedule/view?event=11",
+                   service.event_url(11))
+      assert_equal("http://example.com/path/to/schedule/view?event=22",
+                   service.event_url(22))
+    end
+
+    test 'endpoint with query' do
+      opts = {
+        garoon_endpoint: "http://example.com/path/to?param=value&key=value",
+        garoon_username: "username",
+        garoon_password: "password"
+      }
+      Ragoon.class_variable_set :@@secret_options, opts
+      service = Ragoon::Services::Schedule.new
+      assert_equal("http://example.com/path/to/schedule/view?event=11",
+                   service.event_url(11))
+      assert_equal("http://example.com/path/to/schedule/view?event=22",
+                   service.event_url(22))
+    end
+
+    teardown do
+      Ragoon.class_variable_set :@@secret_options, {}
+    end
+  end
+
+end
+


### PR DESCRIPTION
I want to use ragoon in web service for multi users.

```
use_default = Ragoon::Services::Schedule.new

use_arguments = Ragoon::Services::Schedule.new(
  endpoint: 'http://example.com/scripts/garoon/grn.exe',
  username: 'sato',
  password: 'sato'
)
```
