### PR TITLE
📝 raise exception when an error response is received

### DIFF
--- a/lib/ragoon.rb
+++ b/lib/ragoon.rb
@@ -4,6 +4,7 @@ require 'time'
 
 require 'ragoon/version'
 require 'ragoon/xml'
+require 'ragoon/error'
 require 'ragoon/client'
 require 'ragoon/services'
 require 'ragoon/services/schedule'

--- a/lib/ragoon/error.rb
+++ b/lib/ragoon/error.rb
@@ -1,0 +1,24 @@
+class Ragoon::Error < StandardError
+  def initialize(message = nil, details = {})
+    super(message)
+    @details = details
+  end
+
+  attr_reader :details
+
+  def code
+    @details['code']
+  end
+
+  def diagnosis
+    @details['diagnosis']
+  end
+
+  def cause
+    @details['cause']
+  end
+
+  def counter_measure
+    @details['counter_measure']
+  end
+end


### PR DESCRIPTION
I can not judge normal operation and exception in `Ragoon::Services::Schedule#schedule_get_events`.

```ruby
# before
service = Ragoon::Services::Schedule.new
service.schedule_get_events
# => []  <- there is no schedule or happen error :(

# after
service = Ragoon::Services::Schedule.new
service.schedule_get_events
# => <Ragoon::Error: 指定された画面はアクセスできません。>
```

:pray:

reference:
エラー処理 : Garoon SOAP APIの共通仕様 – cybozu developer network 
https://developer.cybozu.io/hc/ja/articles/202228464-Garoon-SOAP-API%E3%81%AE%E5%85%B1%E9%80%9A%E4%BB%95%E6%A7%98#step7