### PR TITLE
:sparkles: Refactor how to specify garoon options

### DIFF
--- a/lib/ragoon.rb
+++ b/lib/ragoon.rb
@@ -15,10 +15,10 @@ module Ragoon
 
   def self.default_options
     {
-      endpoint: ENV['GAROON_ENDPOINT'] || secret_options[:garoon_endpoint] || raise_option_error('endpoint'),
-      username: ENV['GAROON_USERNAME'] || secret_options[:garoon_username] || raise_option_error('username'),
-      password: ENV['GAROON_PASSWORD'] || secret_options[:garoon_password] || raise_option_error('password'),
-      version:  ENV['GAROON_VERSION']  || secret_options[:garoon_version]  || 4
+      endpoint: ENV['GAROON_ENDPOINT'] || raise_option_error('endpoint'),
+      username: ENV['GAROON_USERNAME'] || raise_option_error('username'),
+      password: ENV['GAROON_PASSWORD'] || raise_option_error('password'),
+      version:  ENV['GAROON_VERSION']  || 4
     }
   end
 
@@ -30,8 +30,11 @@ module Ragoon
 
   def self.secret_options
     if @@secret_options.empty?
-      raise '`./.secret_options` is required.' unless File.exists?('./.secret_options')
-      @@secret_options = eval(File.read('./.secret_options'))
+      if File.exist?('./.secret_options')
+        @@secret_options = eval(File.read('./.secret_options'))
+      else
+        @@secret_options = default_options
+      end
     end
     @@secret_options
   end

--- a/lib/ragoon/services.rb
+++ b/lib/ragoon/services.rb
@@ -7,7 +7,7 @@ class Ragoon::Services
 
   attr_reader :client, :action_type
 
-  def initialize(options = Ragoon.default_options)
+  def initialize(options = Ragoon.secret_options)
     @options = options
     @action_type = self.class.name.split('::').pop.downcase.to_sym
     @client = Ragoon::Client.new(self.endpoint, options)

--- a/test/test_ragoon_services.rb
+++ b/test/test_ragoon_services.rb
@@ -47,10 +47,10 @@ class TestRagoonServices < Test::Unit::TestCase
 
     test 'by secret_options' do
       opts = {
-        garoon_endpoint: "http://example.com/by_secret",
-        garoon_username: "username",
-        garoon_password: "password",
-        garoon_version:  3
+        endpoint: "http://example.com/by_secret",
+        username: "username",
+        password: "password",
+        version:  3
       }
       Ragoon.class_variable_set :@@secret_options, opts
       service = Ragoon::Services::Schedule.new
@@ -60,10 +60,10 @@ class TestRagoonServices < Test::Unit::TestCase
 
     test 'with query' do
       opts = {
-        garoon_endpoint: "http://example.com/cgi?p1=val&p2=val",
-        garoon_username: "username",
-        garoon_password: "password",
-        garoon_version:  3
+        endpoint: "http://example.com/cgi?p1=val&p2=val",
+        username: "username",
+        password: "password",
+        version:  3
       }
       Ragoon.class_variable_set :@@secret_options, opts
       service = Ragoon::Services::Schedule.new

--- a/test/test_ragoon_services_schedule.rb
+++ b/test/test_ragoon_services_schedule.rb
@@ -17,12 +17,13 @@ class TestRagoonServicesSchedule < Test::Unit::TestCase
   sub_test_case '.event_url(id)' do
     test 'endpoint without query' do
       opts = {
-        garoon_endpoint: "http://example.com/path/to",
-        garoon_username: "username",
-        garoon_password: "password",
-        garoon_version:  3
+        endpoint: "http://example.com/path/to",
+        username: "username",
+        password: "password",
+        version:  3
       }
       Ragoon.class_variable_set :@@secret_options, opts
+
       service = Ragoon::Services::Schedule.new
       assert_equal("http://example.com/path/to/schedule/view?event=11",
                    service.event_url(11))
@@ -32,12 +33,13 @@ class TestRagoonServicesSchedule < Test::Unit::TestCase
 
     test 'endpoint with query' do
       opts = {
-        garoon_endpoint: "http://example.com/path/to?param=value&key=value",
-        garoon_username: "username",
-        garoon_password: "password",
-        garoon_version:  3
+        endpoint: "http://example.com/path/to?param=value&key=value",
+        username: "username",
+        password: "password",
+        version:  3
       }
       Ragoon.class_variable_set :@@secret_options, opts
+
       service = Ragoon::Services::Schedule.new
       assert_equal("http://example.com/path/to/schedule/view?event=11",
                    service.event_url(11))


### PR DESCRIPTION
* To specify garoon options, use Ragoon.secret_options instead of Ragoon.default_options
* Prioritize exixtence of `.secret_options` file
* Fix test