### PR TITLE
:repeat: Retry request when authorization failed

### DIFF
--- a/lib/ragoon.rb
+++ b/lib/ragoon.rb
@@ -19,7 +19,8 @@ module Ragoon
       endpoint: ENV['GAROON_ENDPOINT'] || raise_option_error('endpoint'),
       username: ENV['GAROON_USERNAME'] || raise_option_error('username'),
       password: ENV['GAROON_PASSWORD'] || raise_option_error('password'),
-      version:  ENV['GAROON_VERSION']  || 4
+      version:  ENV['GAROON_VERSION']  || 4,
+      retry:    ENV['GAROON_RETRY']    || 10,
     }
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,7 +12,8 @@ TEST_ENDPOINT_OPTS = {
   endpoint: 'http://onlinedemo2.cybozu.info/scripts/garoon/grn.exe',
   username: 'sato',
   password: 'sato',
-  version:  3
+  version:  3,
+  retry:    1
 }
 
 module TestHelper

--- a/test/test_ragoon_services.rb
+++ b/test/test_ragoon_services.rb
@@ -30,6 +30,7 @@ class TestRagoonServices < Test::Unit::TestCase
       ENV['GAROON_USERNAME'] = "username"
       ENV['GAROON_PASSWORD'] = "password"
       ENV['GAROON_VERSION']  = '3'
+      ENV['GAROON_RETRY']    = '1'
       service = Ragoon::Services::Schedule.new
       assert_equal("http://example.com/by_env/cbpapi/schedule/api?",
                    service.endpoint)
@@ -40,6 +41,7 @@ class TestRagoonServices < Test::Unit::TestCase
       ENV['GAROON_USERNAME'] = "username"
       ENV['GAROON_PASSWORD'] = "password"
       ENV['GAROON_VERSION']  = '4'
+      ENV['GAROON_RETRY']    = '1'
       service = Ragoon::Services::Schedule.new
       assert_equal("http://example.com/by_env/cbpapi/schedule/api.csp?",
                    service.endpoint)
@@ -50,7 +52,8 @@ class TestRagoonServices < Test::Unit::TestCase
         endpoint: "http://example.com/by_secret",
         username: "username",
         password: "password",
-        version:  3
+        version:  3,
+        retry:    1,
       }
       Ragoon.class_variable_set :@@secret_options, opts
       service = Ragoon::Services::Schedule.new
@@ -63,7 +66,8 @@ class TestRagoonServices < Test::Unit::TestCase
         endpoint: "http://example.com/cgi?p1=val&p2=val",
         username: "username",
         password: "password",
-        version:  3
+        version:  3,
+        retry:    1,
       }
       Ragoon.class_variable_set :@@secret_options, opts
       service = Ragoon::Services::Schedule.new
@@ -76,7 +80,8 @@ class TestRagoonServices < Test::Unit::TestCase
         endpoint: "http://example.com/by_arg",
         username: "username",
         password: "password",
-        version:  3
+        version:  3,
+        retry:    1
       )
       assert_equal("http://example.com/by_arg/cbpapi/schedule/api?",
                    service.endpoint)
@@ -87,6 +92,7 @@ class TestRagoonServices < Test::Unit::TestCase
       ENV.delete('GAROON_USERNAME')
       ENV.delete('GAROON_PASSWORD')
       ENV.delete('GAROON_VERSION')
+      ENV.delete('GAROON_RETRY')
       Ragoon.class_variable_set :@@secret_options, {}
     end
   end
@@ -97,6 +103,7 @@ class TestRagoonServices < Test::Unit::TestCase
       ENV['GAROON_USERNAME'] = "username"
       ENV['GAROON_PASSWORD'] = "password"
       ENV['GAROON_VERSION']  = '3'
+      ENV['GAROON_RETRY']    = '1'
       @service = Ragoon::Services::Schedule.new
     end
 
@@ -109,6 +116,7 @@ class TestRagoonServices < Test::Unit::TestCase
       ENV.delete('GAROON_USERNAME')
       ENV.delete('GAROON_PASSWORD')
       ENV.delete('GAROON_VERSION')
+      ENV.delete('GAROON_RETRY')
     end
   end
 end

--- a/test/test_ragoon_services_schedule.rb
+++ b/test/test_ragoon_services_schedule.rb
@@ -11,7 +11,8 @@ class TestRagoonServicesSchedule < Test::Unit::TestCase
     endpoint: "http://example.com/path/to",
     username: "username",
     password: "password",
-    version:  3
+    version:  3,
+    retry:    1,
   }
 
   sub_test_case '.event_url(id)' do
@@ -20,7 +21,8 @@ class TestRagoonServicesSchedule < Test::Unit::TestCase
         endpoint: "http://example.com/path/to",
         username: "username",
         password: "password",
-        version:  3
+        version:  3,
+        retry:    1
       }
       Ragoon.class_variable_set :@@secret_options, opts
 
@@ -36,7 +38,8 @@ class TestRagoonServicesSchedule < Test::Unit::TestCase
         endpoint: "http://example.com/path/to?param=value&key=value",
         username: "username",
         password: "password",
-        version:  3
+        version:  3,
+        retry:    1
       }
       Ragoon.class_variable_set :@@secret_options, opts
 


### PR DESCRIPTION
* Specify times to retry at `ENV` or `.secret_options`
  * default : 10 times
* Raise `Ragoon::Error` when over retry count or other error was raised